### PR TITLE
Refactor api module

### DIFF
--- a/src/clone.rs
+++ b/src/clone.rs
@@ -1,4 +1,5 @@
-use crate::api::{list_org_repos, RemoteRepo};
+use crate::github;
+use crate::github::{NoReposFound, RemoteRepo, Unauthorized};
 
 use anyhow::{Context, Result};
 
@@ -43,13 +44,13 @@ fn get_user_token() -> Result<String> {
 }
 
 fn get_remote_repos(token: &str, org: &str) -> Result<Vec<RemoteRepo>> {
-    match list_org_repos(token, org).context("Fetching repositories") {
+    match github::list_org_repos(token, org).context("Fetching repositories") {
         Ok(repos) => Ok(repos),
         Err(e) => {
-            if let Some(_) = e.downcast_ref::<crate::api::NoReposFound>() {
+            if let Some(_) = e.downcast_ref::<NoReposFound>() {
                 anyhow::bail!("No repositories found");
             }
-            if let Some(_) = e.downcast_ref::<crate::api::Unauthorized>() {
+            if let Some(_) = e.downcast_ref::<Unauthorized>() {
                 anyhow::bail!("User token invalid. Run dadmin init with a valid token");
             }
             return Err(e);

--- a/src/convert.rs
+++ b/src/convert.rs
@@ -1,5 +1,5 @@
-use crate::api::RemoteRepo;
 use crate::git::models::GitRepo;
+use crate::github::RemoteRepo;
 use crate::path::get_local_path;
 use std::convert::TryFrom;
 

--- a/src/create_branch.rs
+++ b/src/create_branch.rs
@@ -1,4 +1,5 @@
-use crate::api::{list_org_repos, RemoteRepo};
+use crate::github;
+use crate::github::{NoReposFound, RemoteRepo, Unauthorized};
 use std::convert::TryFrom;
 
 use anyhow::{Context, Result};
@@ -86,13 +87,13 @@ fn get_user_token() -> Result<String> {
 }
 
 fn get_remote_repos(token: &str, org: &str) -> Result<Vec<RemoteRepo>> {
-    match list_org_repos(token, org).context("Fetching repositories") {
+    match github::list_org_repos(token, org).context("Fetching repositories") {
         Ok(repos) => Ok(repos),
         Err(e) => {
-            if let Some(_) = e.downcast_ref::<crate::api::NoReposFound>() {
+            if let Some(_) = e.downcast_ref::<NoReposFound>() {
                 anyhow::bail!("No repositories found");
             }
-            if let Some(_) = e.downcast_ref::<crate::api::Unauthorized>() {
+            if let Some(_) = e.downcast_ref::<Unauthorized>() {
                 anyhow::bail!("User token invalid. Run dadmin init with a valid token");
             }
             return Err(e);

--- a/src/default_branch.rs
+++ b/src/default_branch.rs
@@ -1,6 +1,5 @@
-use crate::api;
-use crate::api::RemoteRepo;
-use crate::rest_api;
+use crate::github;
+use crate::github::{NoReposFound, RemoteRepo, Unauthorized};
 
 use anyhow::{Context, Result};
 
@@ -42,7 +41,7 @@ impl DefaultBranchArgs {
 }
 
 fn set_default_branch(repo: &RemoteRepo, default_branch: &str, token: &str) -> Result<()> {
-    rest_api::set_default_branch(repo, default_branch, token)
+    github::set_default_branch(repo, default_branch, token)
 }
 
 fn get_user_token() -> Result<String> {
@@ -51,13 +50,13 @@ fn get_user_token() -> Result<String> {
 }
 
 fn get_remote_repos(token: &str, org: &str) -> Result<Vec<RemoteRepo>> {
-    match api::list_org_repos(token, org).context("Fetching repositories") {
+    match github::list_org_repos(token, org).context("Fetching repositories") {
         Ok(repos) => Ok(repos),
         Err(e) => {
-            if let Some(_) = e.downcast_ref::<crate::api::NoReposFound>() {
+            if let Some(_) = e.downcast_ref::<NoReposFound>() {
                 anyhow::bail!("No repositories found");
             }
-            if let Some(_) = e.downcast_ref::<crate::api::Unauthorized>() {
+            if let Some(_) = e.downcast_ref::<Unauthorized>() {
                 anyhow::bail!("User token invalid. Run dadmin init with a valid token");
             }
             return Err(e);

--- a/src/filter.rs
+++ b/src/filter.rs
@@ -1,4 +1,4 @@
-use crate::api::RemoteRepo;
+use crate::github::RemoteRepo;
 use regex::{Error as RegexError, Regex, RegexBuilder};
 use std::{fmt, str::FromStr};
 

--- a/src/github/graphql.rs
+++ b/src/github/graphql.rs
@@ -1,5 +1,6 @@
+use super::models::*;
 use graphql_client::{GraphQLQuery, Response};
-use reqwest::{blocking as req, StatusCode};
+use reqwest::blocking as req;
 use serde::Serialize;
 
 type URI = String;
@@ -29,26 +30,6 @@ struct OrganizationRepositories;
 )]
 struct RepositoryDefaultBranch;
 
-#[derive(thiserror::Error, Debug)]
-#[error("User unauthorized")]
-pub struct Unauthorized;
-
-#[derive(thiserror::Error, Debug)]
-#[error("Unsuccessful request with status code: {0}")]
-pub struct Unsuccessful(pub StatusCode);
-
-#[derive(thiserror::Error, Debug)]
-#[error("invalid response when fetching repositories")]
-pub struct InvalidRepoResponse;
-
-#[derive(thiserror::Error, Debug)]
-#[error("no repositories found")]
-pub struct NoReposFound;
-
-#[derive(thiserror::Error, Debug)]
-#[error("No default branch")]
-pub struct NoDefaultBranch;
-
 fn query<T: Serialize + ?Sized>(token: &str, body: &T) -> Result<req::Response, reqwest::Error> {
     let client = req::Client::new();
     client
@@ -74,13 +55,6 @@ pub fn is_valid_token(token: &str) -> anyhow::Result<()> {
     }
 
     Ok(())
-}
-
-#[derive(Debug, Clone)]
-pub struct RemoteRepo {
-    pub name: String,
-    pub ssh_url: GitSSHRemote,
-    pub owner: String,
 }
 
 pub fn list_org_repos(token: &str, org: &str) -> anyhow::Result<Vec<RemoteRepo>> {

--- a/src/github/mod.rs
+++ b/src/github/mod.rs
@@ -1,0 +1,7 @@
+pub mod graphql;
+pub mod models;
+pub mod rest;
+
+pub use graphql::*;
+pub use models::*;
+pub use rest::*;

--- a/src/github/models.rs
+++ b/src/github/models.rs
@@ -1,0 +1,28 @@
+use reqwest::StatusCode;
+
+#[derive(Debug, Clone)]
+pub struct RemoteRepo {
+    pub name: String,
+    pub ssh_url: String,
+    pub owner: String,
+}
+
+#[derive(thiserror::Error, Debug)]
+#[error("User unauthorized")]
+pub struct Unauthorized;
+
+#[derive(thiserror::Error, Debug)]
+#[error("Unsuccessful request with status code: {0}")]
+pub struct Unsuccessful(pub StatusCode);
+
+#[derive(thiserror::Error, Debug)]
+#[error("invalid response when fetching repositories")]
+pub struct InvalidRepoResponse;
+
+#[derive(thiserror::Error, Debug)]
+#[error("no repositories found")]
+pub struct NoReposFound;
+
+#[derive(thiserror::Error, Debug)]
+#[error("No default branch")]
+pub struct NoDefaultBranch;

--- a/src/github/rest.rs
+++ b/src/github/rest.rs
@@ -1,5 +1,5 @@
-use super::api;
-use super::api::RemoteRepo;
+use super::models;
+use super::models::RemoteRepo;
 use anyhow::Result;
 use reqwest::{blocking as req, StatusCode};
 use serde::Serialize;
@@ -32,11 +32,11 @@ pub fn set_default_branch(repo: &RemoteRepo, branch: &str, token: &str) -> Resul
     let response = patch(&url, &body, token)?;
     let status = response.status();
     if status == StatusCode::UNAUTHORIZED {
-        return Err(api::Unauthorized.into());
+        return Err(models::Unauthorized.into());
     }
 
     if !status.is_success() {
-        return Err(api::Unsuccessful(status).into());
+        return Err(models::Unsuccessful(status).into());
     }
 
     Ok(())

--- a/src/list_repo.rs
+++ b/src/list_repo.rs
@@ -1,7 +1,8 @@
 use anyhow::{Context, Result};
 
-use crate::api::{list_org_repos, RemoteRepo};
 use crate::filter::{Filter, Filterable};
+use crate::github;
+use crate::github::{NoReposFound, RemoteRepo, Unauthorized};
 use structopt::StructOpt;
 
 #[derive(Debug, StructOpt)]
@@ -32,13 +33,13 @@ fn get_user_token() -> Result<String> {
 }
 
 fn get_remote_repos(token: &str, org: &str) -> Result<Vec<RemoteRepo>> {
-    match list_org_repos(token, org).context("Fetching repositories") {
+    match github::list_org_repos(token, org).context("Fetching repositories") {
         Ok(repos) => Ok(repos),
         Err(e) => {
-            if let Some(_) = e.downcast_ref::<crate::api::NoReposFound>() {
+            if let Some(_) = e.downcast_ref::<NoReposFound>() {
                 anyhow::bail!("No repositories found");
             }
-            if let Some(_) = e.downcast_ref::<crate::api::Unauthorized>() {
+            if let Some(_) = e.downcast_ref::<Unauthorized>() {
                 anyhow::bail!("User token invalid. Run dadmin init with a valid token");
             }
             return Err(e);

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,3 @@
-mod api;
 mod cli;
 mod clone;
 mod config;
@@ -7,9 +6,9 @@ mod create_branch;
 mod default_branch;
 mod filter;
 mod git;
+mod github;
 mod list_repo;
 mod path;
-mod rest_api;
 mod toml;
 mod user;
 
@@ -34,7 +33,7 @@ fn main() -> Result<()> {
         Commands::Init(InitArgs { root, token }) => {
             let user = match User::new(token) {
                 Ok(user) => { user },
-                Err(e) => match e.downcast_ref::<api::Unauthorized>() {
+                Err(e) => match e.downcast_ref::<github::Unauthorized>() {
                     Some(_) => anyhow::bail!("Token is invalid. Check https://help.github.com/en/github/authenticating-to-github/creating-a-personal-access-token-for-the-command-line"),
                     _ => return Err(e)
                 }

--- a/src/user.rs
+++ b/src/user.rs
@@ -1,3 +1,4 @@
+use super::github;
 use super::path::user_path;
 use super::toml::{read_file, write_to_file};
 use anyhow::Result;
@@ -11,7 +12,7 @@ pub struct User {
 
 impl User {
     pub fn new(token: String) -> Result<User> {
-        super::api::is_valid_token(&token)?;
+        github::is_valid_token(&token)?;
         let user = User { token };
         println!("Authorization successful!");
         Ok(user)


### PR DESCRIPTION
Group all api calls into `github` module. So that other modules can use api with github:: prefix and don't need to know about api's specific mechanism (rest or graphql).

This is also making us easy to change to (or support more) other platform if needed.