### PR TITLE
Implement add users to a team feature

### DIFF
--- a/src/commands/add_users.rs
+++ b/src/commands/add_users.rs
@@ -10,26 +10,71 @@ pub struct AddUsersArgs {
     #[structopt(long, short, default_value = "divvun")]
     pub organisation: String,
     #[structopt(long, short, default_value = "member")]
-    pub role: String,
+    pub role: String, // Fixme we can change this one to an enum Role = Owner | Member
     #[structopt(long, short)]
     pub users: Vec<String>,
+    #[structopt(long, short)]
+    pub team_name: Option<String>,
 }
 
 impl AddUsersArgs {
-    pub fn add_users_to_org(&self) -> Result<()> {
+    pub fn add_users(&self) -> Result<()> {
+        match &self.team_name {
+            Some(name) => self.add_users_to_team(&name),
+            None => self.add_users_to_org(),
+        }
+    }
+
+    fn add_users_to_org(&self) -> Result<()> {
         let user_token = common::get_user_token()?;
 
         let users: Vec<String> = self.users.iter().map(|s| s.to_string()).collect();
 
         let results = add_list_user_to_org(&self.organisation, &self.role, users, &user_token);
 
-        print_results(&results, &self.organisation, &self.role);
+        print_results_org(&results, &self.organisation, &self.role);
+
+        Ok(())
+    }
+
+    fn add_users_to_team(&self, team_name: &str) -> Result<()> {
+        let user_token = common::get_user_token()?;
+
+        let users: Vec<String> = self.users.iter().map(|s| s.to_string()).collect();
+
+        let results = add_list_user_to_team(
+            &self.organisation,
+            team_name,
+            &self.role,
+            users,
+            &user_token,
+        );
+
+        print_results_team(&results, team_name, &self.role);
 
         Ok(())
     }
 }
 
-pub fn add_list_user_to_org(
+fn add_list_user_to_team(
+    org: &str,
+    team: &str,
+    role: &str,
+    users: Vec<String>,
+    token: &str,
+) -> Vec<(String, Result<()>)> {
+    users
+        .into_iter()
+        .map(|u| {
+            (
+                u.clone(),
+                github::add_user_to_team(org, team, role, &u, token),
+            )
+        })
+        .collect()
+}
+
+fn add_list_user_to_org(
     org: &str,
     role: &str,
     users: Vec<String>,
@@ -41,7 +86,7 @@ pub fn add_list_user_to_org(
         .collect()
 }
 
-fn print_results(results: &[(String, Result<()>)], org: &str, role: &str) {
+fn print_results_org(results: &[(String, Result<()>)], org: &str, role: &str) {
     for (user, result) in results {
         match result {
             Ok(_) => println!(
@@ -51,6 +96,21 @@ fn print_results(results: &[(String, Result<()>)], org: &str, role: &str) {
             Err(e) => println!(
                 "Failed to invite user {} to {} with {} role because of {}",
                 user, org, role, e
+            ),
+        }
+    }
+}
+
+fn print_results_team(results: &[(String, Result<()>)], team: &str, role: &str) {
+    for (user, result) in results {
+        match result {
+            Ok(_) => println!(
+                "Invited successfully user {} to team {} with {} role",
+                user, team, role
+            ),
+            Err(e) => println!(
+                "Failed to invite user {} to team {} with {} role because of {}.\n Please notice that you need to add users to your organisation before adding them to a team.",
+                user, team, role, e
             ),
         }
     }

--- a/src/commands/add_users.rs
+++ b/src/commands/add_users.rs
@@ -14,12 +14,12 @@ pub struct AddUsersArgs {
     #[structopt(long, short)]
     pub users: Vec<String>,
     #[structopt(long, short)]
-    pub team_name: Option<String>,
+    pub team_slug: Option<String>,
 }
 
 impl AddUsersArgs {
     pub fn add_users(&self) -> Result<()> {
-        match &self.team_name {
+        match &self.team_slug {
             Some(name) => self.add_users_to_team(&name),
             None => self.add_users_to_org(),
         }

--- a/src/github/rest.rs
+++ b/src/github/rest.rs
@@ -181,6 +181,21 @@ pub struct CreateTeamResponse {
     pub html_url: String,
 }
 
+pub fn add_user_to_team(org: &str, team: &str, role: &str, user: &str, token: &str) -> Result<()> {
+    let url = format!(
+        "https://api.github.com/orgs/{}/teams/{}/memberships/{}",
+        org, team, user
+    );
+
+    let body = AddUserToOrgBody {
+        role: role.to_string(),
+    };
+
+    let response = put(&url, &body, token)?;
+
+    process_response(&response).map(|_| ())
+}
+
 pub fn add_user_to_org(org: &str, role: &str, user: &str, token: &str) -> Result<()> {
     let url = format!("https://api.github.com/orgs/{}/memberships/{}", org, user);
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -45,7 +45,7 @@ fn main() -> Result<()> {
         Commands::DefaultBranch(args) => args.set_default_branch(),
         Commands::ProtectedBranch(args) => args.set_protected_branch(),
         Commands::CreateTeam(args) => args.create_team(),
-        Commands::AddUsers(args) => args.add_users_to_org(),
+        Commands::AddUsers(args) => args.add_users(),
         _ => Ok(()),
     }
 }


### PR DESCRIPTION
Now add-users command will serve both add users to an organization or a team.

`team-name` is optional in the command. So if there is no `team_slug` the command will add list users to an organization. If there is a `team_slugs` the command will add list users to the team.