### PR TITLE
Add remove users command

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,7 +1,7 @@
 use super::path::RootDirectory;
 use crate::commands::{
     AddUsersArgs, CloneArgs, CreateBranchArgs, CreateTeamArgs, DefaultBranchArgs, ListRepoArgs,
-    ProtectedBranchArgs,
+    ProtectedBranchArgs, RemoveUsersArgs,
 };
 use crate::filter::Filter;
 use structopt::StructOpt;
@@ -33,6 +33,8 @@ pub enum Commands {
     CreateTeam(CreateTeamArgs),
     #[structopt(name = "au", aliases = &["add-users"])]
     AddUsers(AddUsersArgs),
+    #[structopt(name = "ru", aliases = &["remove-users"])]
+    RemoveUsers(RemoveUsersArgs),
 }
 
 #[derive(Debug, StructOpt)]

--- a/src/commands/add_users.rs
+++ b/src/commands/add_users.rs
@@ -56,6 +56,18 @@ impl AddUsersArgs {
     }
 }
 
+fn add_list_user_to_org(
+    org: &str,
+    role: &str,
+    users: Vec<String>,
+    token: &str,
+) -> Vec<(String, Result<()>)> {
+    users
+        .into_iter()
+        .map(|u| (u.clone(), github::add_user_to_org(org, role, &u, token)))
+        .collect()
+}
+
 fn add_list_user_to_team(
     org: &str,
     team: &str,
@@ -71,18 +83,6 @@ fn add_list_user_to_team(
                 github::add_user_to_team(org, team, role, &u, token),
             )
         })
-        .collect()
-}
-
-fn add_list_user_to_org(
-    org: &str,
-    role: &str,
-    users: Vec<String>,
-    token: &str,
-) -> Vec<(String, Result<()>)> {
-    users
-        .into_iter()
-        .map(|u| (u.clone(), github::add_user_to_org(org, role, &u, token)))
         .collect()
 }
 

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -6,6 +6,7 @@ pub mod create_team;
 pub mod default_branch;
 pub mod list_repo;
 pub mod protected_branch;
+pub mod remove_users;
 
 pub use add_users::*;
 pub use clone::*;
@@ -14,3 +15,4 @@ pub use create_team::*;
 pub use default_branch::*;
 pub use list_repo::*;
 pub use protected_branch::*;
+pub use remove_users::*;

--- a/src/commands/remove_users.rs
+++ b/src/commands/remove_users.rs
@@ -1,0 +1,33 @@
+use super::common;
+use crate::github;
+
+use anyhow::Result;
+
+use structopt::StructOpt;
+
+#[derive(Debug, StructOpt)]
+pub struct RemoveUsersArgs {
+    #[structopt(long, short, default_value = "divvun")]
+    pub organisation: String,
+    #[structopt(long, short)]
+    pub users: Vec<String>,
+    #[structopt(long, short)]
+    pub team_slug: Option<String>,
+}
+
+impl RemoveUsersArgs {
+    pub fn remove_users(&self) -> Result<()> {
+        match &self.team_slug {
+            Some(name) => self.remove_users_for_team(&name),
+            None => self.remove_users_for_org(),
+        }
+    }
+
+    fn remove_users_for_team(name: &str) -> Result<()>{
+        Ok(())
+    }
+
+    fn remove_users_for_org() -> Result<()> {
+        Ok(())
+    }
+}

--- a/src/commands/remove_users.rs
+++ b/src/commands/remove_users.rs
@@ -18,16 +18,97 @@ pub struct RemoveUsersArgs {
 impl RemoveUsersArgs {
     pub fn remove_users(&self) -> Result<()> {
         match &self.team_slug {
-            Some(name) => self.remove_users_for_team(&name),
-            None => self.remove_users_for_org(),
+            Some(name) => self.remove_users_from_team(&name),
+            None => self.remove_users_from_org(),
         }
     }
 
-    fn remove_users_for_team(name: &str) -> Result<()>{
+    fn remove_users_from_org(&self) -> Result<()> {
+
+        let user_token = common::get_user_token()?;
+
+        let users: Vec<String> = self.users.iter().map(|s| s.to_string()).collect();
+
+        let results = remove_list_user_from_org(&self.organisation, users, &user_token);
+
+        print_results_org(&results, &self.organisation);
+
         Ok(())
     }
 
-    fn remove_users_for_org() -> Result<()> {
+    fn remove_users_from_team(&self, team_name: &str) -> Result<()>{
+        let user_token = common::get_user_token()?;
+
+        let users: Vec<String> = self.users.iter().map(|s| s.to_string()).collect();
+
+        let results = remove_list_user_from_team(
+            &self.organisation,
+            team_name,
+            users,
+            &user_token,
+        );
+
+        print_results_team(&results, team_name);
+
         Ok(())
+    }
+
+}
+
+fn remove_list_user_from_org(
+    org: &str,
+    users: Vec<String>,
+    token: &str,
+) -> Vec<(String, Result<()>)> {
+    users
+        .into_iter()
+        .map(|u| (u.clone(), github::remove_user_from_org(org, &u, token)))
+        .collect()
+}
+
+fn remove_list_user_from_team(
+    org: &str,
+    team: &str,
+    users: Vec<String>,
+    token: &str,
+) -> Vec<(String, Result<()>)> {
+    users
+        .into_iter()
+        .map(|u| {
+            (
+                u.clone(),
+                github::remove_user_from_team(org, team, &u, token),
+            )
+        })
+        .collect()
+}
+
+fn print_results_org(results: &[(String, Result<()>)], org: &str) {
+    for (user, result) in results {
+        match result {
+            Ok(_) => println!(
+                "Removed successfully user {} from {}",
+                user, org
+            ),
+            Err(e) => println!(
+                "Failed to remove user {} to {} because of {}",
+                user, org, e
+            ),
+        }
+    }
+}
+
+fn print_results_team(results: &[(String, Result<()>)], team: &str) {
+    for (user, result) in results {
+        match result {
+            Ok(_) => println!(
+                "Removed successfully user {} from team {}",
+                user, team
+            ),
+            Err(e) => println!(
+                "Failed to remove user {} from team {} because of {}",
+                user, team, e
+            ),
+        }
     }
 }

--- a/src/commands/remove_users.rs
+++ b/src/commands/remove_users.rs
@@ -24,7 +24,6 @@ impl RemoveUsersArgs {
     }
 
     fn remove_users_from_org(&self) -> Result<()> {
-
         let user_token = common::get_user_token()?;
 
         let users: Vec<String> = self.users.iter().map(|s| s.to_string()).collect();
@@ -36,23 +35,17 @@ impl RemoveUsersArgs {
         Ok(())
     }
 
-    fn remove_users_from_team(&self, team_name: &str) -> Result<()>{
+    fn remove_users_from_team(&self, team_name: &str) -> Result<()> {
         let user_token = common::get_user_token()?;
 
         let users: Vec<String> = self.users.iter().map(|s| s.to_string()).collect();
 
-        let results = remove_list_user_from_team(
-            &self.organisation,
-            team_name,
-            users,
-            &user_token,
-        );
+        let results = remove_list_user_from_team(&self.organisation, team_name, users, &user_token);
 
         print_results_team(&results, team_name);
 
         Ok(())
     }
-
 }
 
 fn remove_list_user_from_org(
@@ -86,14 +79,8 @@ fn remove_list_user_from_team(
 fn print_results_org(results: &[(String, Result<()>)], org: &str) {
     for (user, result) in results {
         match result {
-            Ok(_) => println!(
-                "Removed successfully user {} from {}",
-                user, org
-            ),
-            Err(e) => println!(
-                "Failed to remove user {} to {} because of {}",
-                user, org, e
-            ),
+            Ok(_) => println!("Removed successfully user {} from {}", user, org),
+            Err(e) => println!("Failed to remove user {} to {} because of {}", user, org, e),
         }
     }
 }
@@ -101,10 +88,7 @@ fn print_results_org(results: &[(String, Result<()>)], org: &str) {
 fn print_results_team(results: &[(String, Result<()>)], team: &str) {
     for (user, result) in results {
         match result {
-            Ok(_) => println!(
-                "Removed successfully user {} from team {}",
-                user, team
-            ),
+            Ok(_) => println!("Removed successfully user {} from team {}", user, team),
             Err(e) => println!(
                 "Failed to remove user {} from team {} because of {}",
                 user, team, e

--- a/src/github/rest.rs
+++ b/src/github/rest.rs
@@ -52,6 +52,17 @@ fn post<T: Serialize + ?Sized>(
         .send()
 }
 
+fn delete(url: &str, token: &str) -> Result<req::Response, reqwest::Error> {
+    log::debug!("DELETE: {}", url);
+    let client = req::Client::new();
+    client
+        .delete(url)
+        .bearer_auth(token)
+        .header("User-Agent", "dadmin")
+        .header("Accept", "application/vnd.github.v3+json")
+        .send()
+}
+
 #[derive(Serialize, Debug)]
 struct DefaultBranch {
     default_branch: String,
@@ -179,6 +190,25 @@ struct CreateTeamBody {
 pub struct CreateTeamResponse {
     pub id: i32,
     pub html_url: String,
+}
+
+pub fn remove_user_from_org(org: &str, user: &str, token: &str) -> Result<()> {
+    let url = format!("https://api.github.com/orgs/{}/memberships/{}", org, user);
+
+    let response = delete(&url, token)?;
+
+    process_response(&response).map(|_| ())
+}
+
+pub fn remove_user_from_team(org: &str, team: &str, user: &str, token: &str) -> Result<()> {
+    let url = format!(
+        "https://api.github.com/orgs/{}/teams/{}/memberships/{}",
+        org, team, user
+    );
+
+    let response = delete(&url, token)?;
+
+    process_response(&response).map(|_| ())
 }
 
 pub fn add_user_to_team(org: &str, team: &str, role: &str, user: &str, token: &str) -> Result<()> {

--- a/src/main.rs
+++ b/src/main.rs
@@ -46,6 +46,7 @@ fn main() -> Result<()> {
         Commands::ProtectedBranch(args) => args.set_protected_branch(),
         Commands::CreateTeam(args) => args.create_team(),
         Commands::AddUsers(args) => args.add_users(),
+        Commands::RemoveUsers(args) => args.remove_users(),
         _ => Ok(()),
     }
 }


### PR DESCRIPTION
Implement `remove-users` (`ru` for short) command.

This command servers two functions: remove list of user from an organization or from a team.

Example:

Remove member1 and member2 from divvun
`dadmin ru -o divvun -u member1 member2`

Remove member1 and member2 from team-awesome of divvun
`dadmin ru -o divvun -u -t team-awsome member1 member2`
