### PR TITLE
Create new reposiotory

### DIFF
--- a/src/commands/create.rs
+++ b/src/commands/create.rs
@@ -1,3 +1,4 @@
+use super::create_repo::*;
 use super::create_branch::*;
 use super::create_discussion::*;
 use super::create_team::*;
@@ -12,6 +13,8 @@ pub enum CreateArgs {
     Discussion(CreateDiscussionArgs),
     #[structopt(name = "branch")]
     Branch(CreateBranchArgs),
+    #[structopt(name = "repo", aliases = &["repository"])]
+    Repo(CreateRepoArgs),
 }
 
 impl CreateArgs {
@@ -20,6 +23,7 @@ impl CreateArgs {
             CreateArgs::Discussion(args) => args.create_discusstion(),
             CreateArgs::Team(args) => args.create_team(),
             CreateArgs::Branch(args) => args.create_branch(),
+            CreateArgs::Repo(args) => args.create_repo(),
         }
     }
 }

--- a/src/commands/create.rs
+++ b/src/commands/create.rs
@@ -1,6 +1,6 @@
-use super::create_repo::*;
 use super::create_branch::*;
 use super::create_discussion::*;
+use super::create_repo::*;
 use super::create_team::*;
 use anyhow::Result;
 use structopt::StructOpt;

--- a/src/commands/create_branch.rs
+++ b/src/commands/create_branch.rs
@@ -77,7 +77,7 @@ fn create_branch(
 
     let git_repo = try_from_one(remote_repo, user, use_https)?;
 
-    let cloned_repo = git_repo.open()?;
+    let cloned_repo = git_repo.open_or_clone()?;
     log::debug!("Cloned repo: {:?}", cloned_repo.path());
 
     branch::create_branch(&cloned_repo, new_branch, base_branch)?;

--- a/src/commands/create_repo.rs
+++ b/src/commands/create_repo.rs
@@ -3,6 +3,7 @@ use crate::convert::try_from_one;
 use crate::github::RemoteRepo;
 use crate::user::User;
 
+use crate::path::Directory;
 use anyhow::Result;
 
 use crate::filter::Filter;
@@ -17,7 +18,7 @@ pub struct CreateRepoArgs {
     #[structopt(long, short)]
     pub regex: Filter,
     #[structopt(long, short)]
-    pub dir: Option<String>,
+    pub dir: Option<Directory>,
     #[structopt(long, short)]
     pub public: bool,
 }

--- a/src/commands/create_repo.rs
+++ b/src/commands/create_repo.rs
@@ -66,8 +66,10 @@ fn create_repo(org: &str, dir: &PathBuf, public: &bool, token: &str) -> Result<(
     let local_repo =
         open::open(dir).with_context(|| format!("{:?} is not a git directory.", dir))?;
     let repo_name = dir
+        .file_name()
+        .ok_or(anyhow!("{:?} does not have a vaild name"))?
         .to_str()
-        .ok_or(anyhow!("{:?} is not a valid name", dir))?;
+        .ok_or(anyhow!("{:?} doesn not have a valid name", dir))?;
     let new_repo = create_org_repo(org, repo_name, public, token)?;
     log::debug!("new created repo: {:?}", new_repo.html_url);
     Ok(())

--- a/src/commands/create_repo.rs
+++ b/src/commands/create_repo.rs
@@ -24,6 +24,8 @@ pub struct CreateRepoArgs {
     pub public: bool,
     #[structopt(long, short)]
     pub use_https: bool,
+    #[structopt(long, short)]
+    pub no_push: bool,
 }
 
 impl CreateRepoArgs {
@@ -47,6 +49,7 @@ impl CreateRepoArgs {
                 &user,
                 &"origin",
                 self.use_https,
+                self.no_push,
             ) {
                 Ok((name, url)) => println!("Created repo for {} successfully at: {}", name, url),
                 Err(e) => println!("Failed to create repo for dir: {:?} because {:?}", &dir, e),
@@ -83,6 +86,7 @@ fn create_repo(
     user: &User,
     remote_name: &str,
     use_https: bool,
+    no_push: bool,
 ) -> Result<(String, String)> {
     let local_repo =
         open::open(dir).with_context(|| format!("{:?} is not a git directory.", dir))?;
@@ -111,8 +115,10 @@ fn create_repo(
 
     let mut remote = local_repo.remote(remote_name, &remote_url)?;
 
-    let cred = GitCredential::from(user);
-    push::push(&local_repo, &mut remote, Some(cred))?;
+    if !no_push {
+        let cred = GitCredential::from(user);
+        push::push(&local_repo, &mut remote, Some(cred))?;
+    }
 
     Ok((repo_name.to_string(), created_repo.html_url))
 }

--- a/src/commands/create_repo.rs
+++ b/src/commands/create_repo.rs
@@ -1,0 +1,30 @@
+use super::common;
+use crate::convert::try_from_one;
+use crate::github::RemoteRepo;
+use crate::user::User;
+
+use anyhow::Result;
+
+use crate::filter::Filter;
+use crate::git::branch;
+use crate::git::push;
+use structopt::StructOpt;
+
+#[derive(Debug, StructOpt)]
+pub struct CreateRepoArgs {
+    #[structopt(long, short, default_value = "divvun")]
+    pub organisation: String,
+    #[structopt(long, short)]
+    pub regex: Filter,
+    #[structopt(long, short)]
+    pub dir: Option<String>,
+    #[structopt(long, short)]
+    pub public: bool,
+}
+
+impl CreateRepoArgs {
+    pub fn create_repo(&self) -> Result<()> {
+        println!("Create Repo {:?}", self);
+        Ok(())
+    }
+}

--- a/src/commands/create_repo.rs
+++ b/src/commands/create_repo.rs
@@ -1,13 +1,15 @@
 use super::common;
 use crate::github::create_org_repo;
+use crate::user::User;
 use std::path::PathBuf;
 
 use crate::path::{local_path_org, Directory};
 use anyhow::{anyhow, Context, Result};
 
 use crate::filter::{Filter, Filterable};
-//use crate::git::push;
 use crate::git::open;
+use crate::git::push;
+use crate::git::GitCredential;
 use structopt::StructOpt;
 
 #[derive(Debug, StructOpt)]
@@ -20,22 +22,34 @@ pub struct CreateRepoArgs {
     pub dir: Option<Directory>,
     #[structopt(long, short)]
     pub public: bool,
+    #[structopt(long, short)]
+    pub use_https: bool,
 }
 
 impl CreateRepoArgs {
     pub fn create_repo(&self) -> Result<()> {
-        println!("Create Repo {:?}", self);
+        log::debug!("Create Repo {:?}", self);
+
         let dir = match &self.dir {
             Some(d) => d.path.clone(),
             None => local_path_org(&self.organisation)?,
         };
+
         let sub_dirs = read_dirs(&dir, &self.regex)?;
-        println!("Filtered sub dirs: {:?}", sub_dirs);
-        let token = common::user_token()?;
+
+        log::debug!("Filtered sub dirs: {:?}", sub_dirs);
+        let user = common::user()?;
         for dir in sub_dirs {
-            match create_repo(&self.organisation, &dir, &self.public, &token) {
-                Ok(_) => println!("Success"),
-                Err(e) => println!("Failed because of {:?}", e),
+            match create_repo(
+                &self.organisation,
+                &dir,
+                self.public,
+                &user,
+                &"origin",
+                self.use_https,
+            ) {
+                Ok((name, url)) => println!("Created repo for {} successfully at: {}", name, url),
+                Err(e) => println!("Failed to create repo for dir: {:?} because {:?}", &dir, e),
             }
         }
         Ok(())
@@ -49,7 +63,6 @@ impl CreateRepoArgs {
 fn read_dirs(path: &PathBuf, filter: &Filter) -> Result<Vec<PathBuf>> {
     let entries = path.read_dir()?;
     let dirs = entries
-        .into_iter()
         .filter_map(|x| x.ok())
         .map(|x| x.path())
         .filter(|x| x.is_dir())
@@ -58,19 +71,48 @@ fn read_dirs(path: &PathBuf, filter: &Filter) -> Result<Vec<PathBuf>> {
 }
 
 /// Check if {dir} is a git repository
+/// Check if {dir} has {remote} remote
 /// Create a new repository in organization {org}
-/// Set the new created repository as remote origin
-/// Push all to remote origin
+/// Set the new created repository as remote {remote}
+/// Push all to remote {remote}
 
-fn create_repo(org: &str, dir: &PathBuf, public: &bool, token: &str) -> Result<()> {
+fn create_repo(
+    org: &str,
+    dir: &PathBuf,
+    public: bool,
+    user: &User,
+    remote_name: &str,
+    use_https: bool,
+) -> Result<(String, String)> {
     let local_repo =
         open::open(dir).with_context(|| format!("{:?} is not a git directory.", dir))?;
+
+    if local_repo.find_remote(remote_name).is_ok() {
+        return Err(anyhow!(
+            "This repo already has a remote named: {}",
+            remote_name
+        ));
+    }
+
     let repo_name = dir
         .file_name()
-        .ok_or(anyhow!("{:?} does not have a vaild name"))?
+        .ok_or_else(|| anyhow!("{:?} does not have a vaild name"))?
         .to_str()
-        .ok_or(anyhow!("{:?} doesn not have a valid name", dir))?;
-    let new_repo = create_org_repo(org, repo_name, public, token)?;
-    log::debug!("new created repo: {:?}", new_repo.html_url);
-    Ok(())
+        .ok_or_else(|| anyhow!("{:?} doesn not have a valid name", dir))?;
+
+    let created_repo = create_org_repo(org, repo_name, public, &user.token)?;
+    log::debug!("new created repo: {:?}", created_repo.html_url);
+
+    let remote_url = if use_https {
+        format!("{}.git", created_repo.html_url.clone())
+    } else {
+        created_repo.ssh_url.clone()
+    };
+
+    let mut remote = local_repo.remote(remote_name, &remote_url)?;
+
+    let cred = GitCredential::from(user);
+    push::push(&local_repo, &mut remote, Some(cred))?;
+
+    Ok((repo_name.to_string(), created_repo.html_url))
 }

--- a/src/commands/create_repo.rs
+++ b/src/commands/create_repo.rs
@@ -1,12 +1,14 @@
+use std::path::PathBuf;
+use std::fs::DirEntry;
 use super::common;
 use crate::convert::try_from_one;
 use crate::github::RemoteRepo;
 use crate::user::User;
 
-use crate::path::Directory;
-use anyhow::Result;
+use crate::path::{Directory, local_path_org};
+use anyhow::{Result, anyhow};
 
-use crate::filter::Filter;
+use crate::filter::{Filter, Filterable};
 use crate::git::branch;
 use crate::git::push;
 use structopt::StructOpt;
@@ -26,6 +28,22 @@ pub struct CreateRepoArgs {
 impl CreateRepoArgs {
     pub fn create_repo(&self) -> Result<()> {
         println!("Create Repo {:?}", self);
+        let dir = match &self.dir {
+            Some(d) => d.path.clone(),
+            None => local_path_org(&self.organisation)?,
+        };
+        let sub_dirs = read_dirs(&dir, &self.regex);
+        println!("Filtered sub dirs: {:?}", sub_dirs);
         Ok(())
     }
+}
+
+fn read_dirs(path: &PathBuf, filter: &Filter) -> Result<Vec<PathBuf>> {
+    let entries = path.read_dir()?;
+    let dirs = entries.into_iter()
+        .filter_map(|x| x.ok())
+        .map(|x| x.path())
+        .filter(|x| x.is_dir())
+        .collect();
+    Ok(PathBuf::filter(dirs, filter))
 }

--- a/src/commands/create_repo.rs
+++ b/src/commands/create_repo.rs
@@ -1,16 +1,13 @@
-use std::path::PathBuf;
-use std::fs::DirEntry;
 use super::common;
-use crate::convert::try_from_one;
-use crate::github::RemoteRepo;
-use crate::user::User;
+use crate::github::create_org_repo;
+use std::path::PathBuf;
 
-use crate::path::{Directory, local_path_org};
-use anyhow::{Result, anyhow};
+use crate::path::{local_path_org, Directory};
+use anyhow::{anyhow, Context, Result};
 
 use crate::filter::{Filter, Filterable};
-use crate::git::branch;
-use crate::git::push;
+//use crate::git::push;
+use crate::git::open;
 use structopt::StructOpt;
 
 #[derive(Debug, StructOpt)]
@@ -32,18 +29,46 @@ impl CreateRepoArgs {
             Some(d) => d.path.clone(),
             None => local_path_org(&self.organisation)?,
         };
-        let sub_dirs = read_dirs(&dir, &self.regex);
+        let sub_dirs = read_dirs(&dir, &self.regex)?;
         println!("Filtered sub dirs: {:?}", sub_dirs);
+        let token = common::user_token()?;
+        for dir in sub_dirs {
+            match create_repo(&self.organisation, &dir, &self.public, &token) {
+                Ok(_) => println!("Success"),
+                Err(e) => println!("Failed because of {:?}", e),
+            }
+        }
         Ok(())
     }
 }
 
+/// Read all dirs inside a path
+/// Filter directories
+/// Filter directory's name by regex
+
 fn read_dirs(path: &PathBuf, filter: &Filter) -> Result<Vec<PathBuf>> {
     let entries = path.read_dir()?;
-    let dirs = entries.into_iter()
+    let dirs = entries
+        .into_iter()
         .filter_map(|x| x.ok())
         .map(|x| x.path())
         .filter(|x| x.is_dir())
         .collect();
     Ok(PathBuf::filter(dirs, filter))
+}
+
+/// Check if {dir} is a git repository
+/// Create a new repository in organization {org}
+/// Set the new created repository as remote origin
+/// Push all to remote origin
+
+fn create_repo(org: &str, dir: &PathBuf, public: &bool, token: &str) -> Result<()> {
+    let local_repo =
+        open::open(dir).with_context(|| format!("{:?} is not a git directory.", dir))?;
+    let repo_name = dir
+        .to_str()
+        .ok_or(anyhow!("{:?} is not a valid name", dir))?;
+    let new_repo = create_org_repo(org, repo_name, public, token)?;
+    log::debug!("new created repo: {:?}", new_repo.html_url);
+    Ok(())
 }

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -1,5 +1,4 @@
 pub mod add;
-pub mod create_repo;
 pub mod add_users;
 pub mod branch;
 pub mod clone;
@@ -7,6 +6,7 @@ pub mod common;
 pub mod create;
 pub mod create_branch;
 pub mod create_discussion;
+pub mod create_repo;
 pub mod create_team;
 pub mod default_branch;
 pub mod init_config;

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -1,4 +1,5 @@
 pub mod add;
+pub mod create_repo;
 pub mod add_users;
 pub mod branch;
 pub mod clone;

--- a/src/filter.rs
+++ b/src/filter.rs
@@ -1,3 +1,4 @@
+use std::path::PathBuf;
 use crate::github::RemoteRepo;
 use regex::{Error as RegexError, Regex, RegexBuilder};
 use std::{fmt, str::FromStr};
@@ -46,5 +47,14 @@ pub trait Filterable {
 impl Filterable for RemoteRepo {
     fn is_match(&self, filter: &Filter) -> bool {
         filter.is_match(&self.name)
+    }
+}
+
+impl Filterable for PathBuf {
+    fn is_match(&self, filter: &Filter) -> bool {
+        match self.to_str() {
+            Some(v) => filter.is_match(v),
+            None => false
+        }
     }
 }

--- a/src/filter.rs
+++ b/src/filter.rs
@@ -1,6 +1,6 @@
-use std::path::PathBuf;
 use crate::github::RemoteRepo;
 use regex::{Error as RegexError, Regex, RegexBuilder};
+use std::path::PathBuf;
 use std::{fmt, str::FromStr};
 
 #[derive(Debug)]
@@ -54,7 +54,7 @@ impl Filterable for PathBuf {
     fn is_match(&self, filter: &Filter) -> bool {
         match self.to_str() {
             Some(v) => filter.is_match(v),
-            None => false
+            None => false,
         }
     }
 }

--- a/src/git/mod.rs
+++ b/src/git/mod.rs
@@ -1,9 +1,11 @@
 pub mod branch;
 pub mod clone;
 pub mod models;
+pub mod open;
 pub mod push;
 
 pub use branch::create_branch;
 pub use clone::{Clonable, CloneError};
 pub use models::*;
+pub use open::*;
 pub use push::push_branch;

--- a/src/git/models.rs
+++ b/src/git/models.rs
@@ -1,3 +1,4 @@
+use super::open;
 use crate::git::clone;
 use crate::user::User;
 use dialoguer::PasswordInput;
@@ -22,12 +23,8 @@ impl clone::Clonable for GitRepo {
 }
 
 impl GitRepo {
-    pub fn open(&self) -> Result<Repository, Error> {
-        match Repository::open(&self.local_path) {
-            Ok(repo) => Ok(repo),
-            Err(_) => clone::clone(&self.remote_url, &self.local_path, self.cred.clone())
-                .map_err(|e| e.source),
-        }
+    pub fn open_or_clone(&self) -> Result<Repository, Error> {
+        open::open_or_clone(&self.local_path, &self.remote_url, &self.cred)
     }
 }
 

--- a/src/git/open.rs
+++ b/src/git/open.rs
@@ -1,0 +1,19 @@
+use super::clone;
+use super::models::GitCredential;
+use git2::{Error, Repository};
+use std::path::PathBuf;
+
+pub fn open(path: &PathBuf) -> Result<Repository, Error> {
+    Repository::open(path)
+}
+
+pub fn open_or_clone(
+    local_path: &PathBuf,
+    remote_url: &str,
+    cred: &Option<GitCredential>,
+) -> Result<Repository, Error> {
+    match Repository::open(local_path) {
+        Ok(repo) => Ok(repo),
+        Err(_) => clone::clone(remote_url, local_path, cred.clone()).map_err(|e| e.source),
+    }
+}

--- a/src/git/push.rs
+++ b/src/git/push.rs
@@ -1,5 +1,5 @@
 use super::models::GitCredential;
-use git2::{Error, Repository};
+use git2::{Error, Remote, Repository};
 use git2_credentials::ui4dialoguer::CredentialUI4Dialoguer;
 use git2_credentials::CredentialHandler;
 use git2_credentials::CredentialUI;
@@ -26,8 +26,8 @@ pub fn push_branch(
     cb.credentials(move |url, username, allowed| ch.try_next_credential(url, username, allowed));
 
     let mut po = git2::PushOptions::new();
-
     po.remote_callbacks(cb);
+
     let result = origin.push(&[&ref_by_branch(branch)], Some(&mut po));
     log::debug!("Push result {:?}", result);
 
@@ -36,4 +36,42 @@ pub fn push_branch(
 
 fn ref_by_branch(branch: &str) -> String {
     format!("refs/heads/{}:refs/heads/{}", branch, branch)
+}
+
+pub fn push(
+    repo: &Repository,
+    remote: &mut Remote,
+    cred: Option<GitCredential>,
+) -> Result<(), Error> {
+    let mut cb = git2::RemoteCallbacks::new();
+    let git_config = git2::Config::open_default()?;
+
+    let credential_ui: Box<dyn CredentialUI> = match cred {
+        Some(gc) => Box::new(gc),
+        _ => Box::new(CredentialUI4Dialoguer {}),
+    };
+
+    // Prepare callbacks.
+    let mut ch = CredentialHandler::new_with_ui(git_config, credential_ui);
+
+    cb.credentials(move |url, username, allowed| ch.try_next_credential(url, username, allowed));
+
+    let mut po = git2::PushOptions::new();
+    po.remote_callbacks(cb);
+
+    let branches: Vec<String> = repo
+        .branches(None)
+        .unwrap()
+        .map(|a| a.unwrap())
+        .map(|(a, _)| a.name().unwrap().unwrap().to_string())
+        .collect();
+
+    log::debug!("Branches {:?}", branches);
+
+    //let refs = [&ref_by_branch("master"), &ref_by_branch("new-branch")];
+    let refs: Vec<String> = branches.iter().map(|a| ref_by_branch(a)).collect();
+
+    let result = remote.push(&refs, Some(&mut po));
+    log::debug!("Push result {:?}", result);
+    Ok(())
 }

--- a/src/github/rest.rs
+++ b/src/github/rest.rs
@@ -320,7 +320,7 @@ struct SetTeamPermissionBody {
 pub fn create_org_repo(
     org: &str,
     name: &str,
-    public: &bool,
+    public: bool,
     token: &str,
 ) -> Result<CreateRepoResponse> {
     let url = format!("https://api.github.com/orgs/{}/repos", org);
@@ -356,6 +356,7 @@ struct CreateRepoBody {
 pub struct CreateRepoResponse {
     pub full_name: String,
     pub html_url: String,
+    pub ssh_url: String,
 }
 
 fn process_response(response: &req::Response) -> Result<&req::Response> {

--- a/src/github/rest.rs
+++ b/src/github/rest.rs
@@ -317,6 +317,47 @@ struct SetTeamPermissionBody {
     permission: String,
 }
 
+pub fn create_org_repo(
+    org: &str,
+    name: &str,
+    public: &bool,
+    token: &str,
+) -> Result<CreateRepoResponse> {
+    let url = format!("https://api.github.com/orgs/{}/repos", org);
+
+    let body = CreateRepoBody {
+        name: name.to_string(),
+        private: !public,
+    };
+
+    let response = post(&url, &body, token)?;
+
+    let status = response.status();
+
+    if status == StatusCode::UNAUTHORIZED {
+        return Err(models::Unauthorized.into());
+    }
+
+    if !status.is_success() {
+        return Err(models::Unsuccessful(status).into());
+    }
+
+    let response_body: CreateRepoResponse = response.json()?;
+    Ok(response_body)
+}
+
+#[derive(Serialize, Debug)]
+struct CreateRepoBody {
+    name: String,
+    private: bool,
+}
+
+#[derive(Deserialize, Debug)]
+pub struct CreateRepoResponse {
+    pub full_name: String,
+    pub html_url: String,
+}
+
 fn process_response(response: &req::Response) -> Result<&req::Response> {
     let status = response.status();
 

--- a/src/path.rs
+++ b/src/path.rs
@@ -110,3 +110,37 @@ impl EnsureDirExists for std::path::PathBuf {
         Ok(self)
     }
 }
+
+#[derive(Debug)]
+pub struct Directory {
+    pub path: String,
+}
+
+impl FromStr for Directory {
+    type Err = DirError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        validate_dir(s).map(|path| Directory { path })
+    }
+}
+#[derive(thiserror::Error, Debug)]
+pub enum DirError {
+    #[error("{path} is not a dir")]
+    NotADir { path: String },
+    #[error("{path} is not exist")]
+    NotExist { path: String },
+}
+
+pub fn validate_dir(dir: &str) -> Result<String, DirError> {
+    let path = Path::new(dir);
+
+    if path.exists() {
+        if path.is_dir() {
+            Ok(dir.to_string())
+        } else {
+            Err(DirError::NotADir{ path: dir.to_string()})
+        }
+    } else {
+        Err(DirError::NotExist{path: dir.to_string()})
+    }
+}

--- a/src/path.rs
+++ b/src/path.rs
@@ -62,7 +62,6 @@ pub fn local_path_org(organisation: &str) -> anyhow::Result<PathBuf> {
     Ok(local_path)
 }
 
-
 #[derive(thiserror::Error, Debug)]
 pub enum RootError {
     #[error("{path} is a file. Root directory cannot be a file")]
@@ -146,9 +145,13 @@ pub fn validate_dir(dir: &str) -> Result<PathBuf, DirError> {
         if path.is_dir() {
             Ok(path.to_path_buf())
         } else {
-            Err(DirError::NotADir{ path: dir.to_string()})
+            Err(DirError::NotADir {
+                path: dir.to_string(),
+            })
         }
     } else {
-        Err(DirError::NotExist{path: dir.to_string()})
+        Err(DirError::NotExist {
+            path: dir.to_string(),
+        })
     }
 }

--- a/src/path.rs
+++ b/src/path.rs
@@ -55,6 +55,14 @@ pub fn local_path(organisation: &str, name: &str) -> Option<PathBuf> {
     Some(local_path)
 }
 
+pub fn local_path_org(organisation: &str) -> anyhow::Result<PathBuf> {
+    let root = Config::root()?;
+    let root_dir = Path::new(&root);
+    let local_path = root_dir.join(organisation);
+    Ok(local_path)
+}
+
+
 #[derive(thiserror::Error, Debug)]
 pub enum RootError {
     #[error("{path} is a file. Root directory cannot be a file")]
@@ -113,7 +121,7 @@ impl EnsureDirExists for std::path::PathBuf {
 
 #[derive(Debug)]
 pub struct Directory {
-    pub path: String,
+    pub path: PathBuf,
 }
 
 impl FromStr for Directory {
@@ -131,12 +139,12 @@ pub enum DirError {
     NotExist { path: String },
 }
 
-pub fn validate_dir(dir: &str) -> Result<String, DirError> {
+pub fn validate_dir(dir: &str) -> Result<PathBuf, DirError> {
     let path = Path::new(dir);
 
     if path.exists() {
         if path.is_dir() {
-            Ok(dir.to_string())
+            Ok(path.to_path_buf())
         } else {
             Err(DirError::NotADir{ path: dir.to_string()})
         }


### PR DESCRIPTION
Address issue #34 

The command looks like: `cargo run -- create repo -o <org> -r <regex> -d <dir> --public --use-https --no-push`

This is a working-in-progress pr. It is 70 percent done.

Below, I will describe how it works:

Step 1: Pick the parent directory, parent directory is specified by `-d` option or otherwise `dadmin_root/{org}` directory.

Step 2: scan all directories inside the parent directory and filter directories that match `regex`

Step 3: for `dir` in filtered_directories do

Step 4: Check if `dir` is a git repository

Step 5a: Check if the repository has a remote named: origin then return and print error message.

Step 5: create new repository in organization `org` with name of `dir`

Step 6: Set remote origin of `dir` by the new created repository

Step 6: Push all to origin.