### PR TITLE
Checkout branch for all repos

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,6 +1,6 @@
 use crate::commands::{
-    AddArgs, BranchArgs, CloneArgs, CreateArgs, InitArgs, PushArgs, RemoveArgs, SetArgs, ShowArgs,
-    CheckoutArgs,
+    AddArgs, BranchArgs, CheckoutArgs, CloneArgs, CreateArgs, InitArgs, PushArgs, RemoveArgs,
+    SetArgs, ShowArgs,
 };
 use structopt::StructOpt;
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,5 +1,6 @@
 use crate::commands::{
     AddArgs, BranchArgs, CloneArgs, CreateArgs, InitArgs, PushArgs, RemoveArgs, SetArgs, ShowArgs,
+    CheckoutArgs,
 };
 use structopt::StructOpt;
 
@@ -16,6 +17,8 @@ pub enum Commands {
     Add(AddArgs),
     #[structopt(name = "branch", aliases = &["br"])]
     Branch(BranchArgs),
+    #[structopt(name = "checkout", aliases = &["co"])]
+    Checkout(CheckoutArgs),
     #[structopt(name = "clone", aliases = &["cl"])]
     Clone(CloneArgs),
     #[structopt(name = "create", aliases = &["cr"])]

--- a/src/commands/checkout.rs
+++ b/src/commands/checkout.rs
@@ -64,7 +64,7 @@ fn checkout_branch(
         let cred = GitCredential::from(user);
         git::checkout_remote_branch(&git_repo, branch, remote_name, Some(cred))?;
     } else {
-        return Err(anyhow!("There is no local branch with name: {}.\n You can you `--remote` option to checkout a remote branch.", branch));
+        return Err(anyhow!("There is no local branch with name: {}.\n You can use `--remote` option to checkout a remote branch.", branch));
     };
 
     Ok(())

--- a/src/commands/checkout.rs
+++ b/src/commands/checkout.rs
@@ -1,13 +1,11 @@
 use super::common;
-use crate::git::open;
+use crate::git;
 use crate::path::local_path_org;
 use crate::user::User;
 
 use anyhow::{Context, Result};
 
 use crate::filter::Filter;
-use crate::git::push;
-use crate::git::GitCredential;
 use std::path::PathBuf;
 use structopt::StructOpt;
 
@@ -24,6 +22,33 @@ pub struct CheckoutArgs {
 impl CheckoutArgs {
     pub fn run(&self) -> Result<()> {
         log::debug!("checkout branch {:?}", self);
+        let user = common::user()?;
+
+        let target_dir = local_path_org(&self.organisation)?;
+
+        let sub_dirs = common::read_dirs(&target_dir, &self.regex)?;
+
+        for dir in sub_dirs {
+            match checkout_branch(&dir, &self.branch, &user, &"origin") {
+                Ok(_) => println!(
+                    "Checkout branch {} of repo {:?} successfully",
+                    &self.branch, dir
+                ),
+                Err(e) => println!(
+                    "Failed to checkout branch {} of repo {:?} because {:?}",
+                    &self.branch, dir, e
+                ),
+            }
+        }
+
         Ok(())
     }
+}
+
+fn checkout_branch(dir: &PathBuf, branch: &str, user: &User, remote_name: &str) -> Result<()> {
+    let git_repo = git::open(dir).with_context(|| format!("{:?} is not a git directory.", dir))?;
+
+    git::checkout_local_branch(&git_repo, branch)?;
+
+    Ok(())
 }

--- a/src/commands/checkout.rs
+++ b/src/commands/checkout.rs
@@ -1,0 +1,29 @@
+use super::common;
+use crate::git::open;
+use crate::path::local_path_org;
+use crate::user::User;
+
+use anyhow::{Context, Result};
+
+use crate::filter::Filter;
+use crate::git::push;
+use crate::git::GitCredential;
+use std::path::PathBuf;
+use structopt::StructOpt;
+
+#[derive(Debug, StructOpt)]
+pub struct CheckoutArgs {
+    #[structopt(long, short)]
+    pub organisation: String,
+    #[structopt(long, short)]
+    pub regex: Filter,
+    #[structopt(long, short)]
+    pub branch: String,
+}
+
+impl CheckoutArgs {
+    pub fn run(&self) -> Result<()> {
+        log::debug!("checkout branch {:?}", self);
+        Ok(())
+    }
+}

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -1,6 +1,7 @@
 pub mod add;
 pub mod add_users;
 pub mod branch;
+pub mod checkout;
 pub mod clone;
 pub mod common;
 pub mod create;
@@ -19,10 +20,10 @@ pub mod set_team_permission;
 pub mod show;
 pub mod show_config;
 pub mod show_repos;
-pub mod checkout;
 
 pub use add::*;
 pub use branch::*;
+pub use checkout::*;
 pub use clone::*;
 pub use create::*;
 pub use init_config::*;
@@ -30,4 +31,3 @@ pub use push::*;
 pub use remove::*;
 pub use set::*;
 pub use show::*;
-pub use checkout::*;

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -19,6 +19,7 @@ pub mod set_team_permission;
 pub mod show;
 pub mod show_config;
 pub mod show_repos;
+pub mod checkout;
 
 pub use add::*;
 pub use branch::*;
@@ -29,3 +30,4 @@ pub use push::*;
 pub use remove::*;
 pub use set::*;
 pub use show::*;
+pub use checkout::*;

--- a/src/commands/push.rs
+++ b/src/commands/push.rs
@@ -38,7 +38,7 @@ impl PushArgs {
                     &self.branch, dir
                 ),
                 Err(e) => println!(
-                    "Failed to pusb branch {} of repo {:?} because {:?}",
+                    "Failed to push branch {} of repo {:?} because {:?}",
                     &self.branch, dir, e
                 ),
             }

--- a/src/git/branch.rs
+++ b/src/git/branch.rs
@@ -1,3 +1,4 @@
+use anyhow::{anyhow, Result};
 use git2::{Branch, BranchType, Error, Repository};
 
 pub trait CreateBranch<'a> {
@@ -15,4 +16,13 @@ pub fn create_branch<'a>(
     let oid = base_branch.get().target().unwrap();
     let commit = repo.find_commit(oid)?;
     repo.branch(new_branch, &commit, false)
+}
+
+pub fn checkout_local_branch<'a>(repo: &'a Repository, branch: &str) -> Result<()> {
+    if repo.find_branch(branch, BranchType::Local).is_err() {
+        return Err(anyhow!("There is no local branch with name: {}", branch));
+    }
+    let ref_to_branch = format!("refs/heads/{}", branch);
+    repo.set_head(&ref_to_branch)?;
+    Ok(())
 }

--- a/src/git/common.rs
+++ b/src/git/common.rs
@@ -1,0 +1,28 @@
+use super::models::GitCredential;
+use git2::Error;
+use git2_credentials::ui4dialoguer::CredentialUI4Dialoguer;
+use git2_credentials::CredentialHandler;
+use git2_credentials::CredentialUI;
+
+pub fn create_remote_callback(
+    cred: &Option<GitCredential>,
+) -> Result<git2::RemoteCallbacks, Error> {
+    let mut cb = git2::RemoteCallbacks::new();
+    let git_config = git2::Config::open_default()?;
+
+    let credential_ui: Box<dyn CredentialUI> = match cred {
+        Some(gc) => Box::new(gc.clone()),
+        _ => Box::new(CredentialUI4Dialoguer {}),
+    };
+
+    // Prepare callbacks.
+    let mut ch = CredentialHandler::new_with_ui(git_config, credential_ui);
+
+    cb.credentials(move |url, username, allowed| ch.try_next_credential(url, username, allowed));
+
+    Ok(cb)
+}
+
+pub fn ref_by_branch(branch: &str) -> String {
+    format!("refs/heads/{}:refs/heads/{}", branch, branch)
+}

--- a/src/git/fetch.rs
+++ b/src/git/fetch.rs
@@ -1,0 +1,23 @@
+use super::common;
+use super::models::GitCredential;
+use git2::{Error, Repository};
+
+// https://github.com/rust-lang/git2-rs/blob/master/examples/fetch.rs
+pub fn fetch_branch(
+    repo: &Repository,
+    branch: &str,
+    remote_name: &str,
+    cred: Option<GitCredential>,
+) -> Result<(), Error> {
+    log::info!("Fetching {} for repo", branch);
+    let mut remote = repo.find_remote(remote_name)?;
+
+    let remote_callbacks = common::create_remote_callback(&cred)?;
+
+    let mut fo = git2::FetchOptions::new();
+    fo.remote_callbacks(remote_callbacks);
+
+    remote.fetch(&[branch], Some(&mut fo), None)?;
+
+    Ok(())
+}

--- a/src/git/mod.rs
+++ b/src/git/mod.rs
@@ -4,7 +4,7 @@ pub mod models;
 pub mod open;
 pub mod push;
 
-pub use branch::create_branch;
+pub use branch::*;
 pub use clone::{Clonable, CloneError};
 pub use models::*;
 pub use open::*;

--- a/src/git/mod.rs
+++ b/src/git/mod.rs
@@ -1,11 +1,14 @@
 pub mod branch;
 pub mod clone;
+pub mod common;
+pub mod fetch;
 pub mod models;
 pub mod open;
 pub mod push;
 
 pub use branch::*;
 pub use clone::{Clonable, CloneError};
+pub use fetch::*;
 pub use models::*;
 pub use open::*;
 pub use push::push_branch;

--- a/src/main.rs
+++ b/src/main.rs
@@ -27,6 +27,7 @@ fn main() -> Result<()> {
     match args.command {
         Commands::Add(args) => args.run(),
         Commands::Branch(args) => args.run(),
+        Commands::Checkout(args) => args.run(),
         Commands::Clone(args) => args.run(),
         Commands::Create(args) => args.run(),
         Commands::Init(args) => args.save_config(),


### PR DESCRIPTION
Close #51 

Our final command looks like: `dadmin checkout -o <org> -r <regex> --branch <branch> --remote`

Without `--remote` option, this command only does local checkout. It's effect is similar to `git checkout branch` command but for multiples repositories.

With `--remote` option, if there is no corresponding branch in local, dadmin will try to fetch the branch and then do checkout as normal.