### PR TITLE
Implement status command

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -161,6 +161,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "bstr"
+version = "0.2.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2889e6d50f394968c8bf4240dc3f2a7eb4680844d27308f798229ac9d4725f41"
+dependencies = [
+ "lazy_static",
+ "memchr",
+ "regex-automata",
+ "serde",
+]
+
+[[package]]
 name = "bumpalo"
 version = "3.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -312,18 +324,41 @@ dependencies = [
 ]
 
 [[package]]
+name = "csv"
+version = "1.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00affe7f6ab566df61b4be3ce8cf16bc2576bca0963ceb0955e45d514bf9a279"
+dependencies = [
+ "bstr",
+ "csv-core",
+ "itoa",
+ "ryu",
+ "serde",
+]
+
+[[package]]
+name = "csv-core"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b2466559f260f48ad25fe6317b3c8dac77b5bdb5763ac7d9d6103530663bc90"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "dadmin"
 version = "0.1.0"
 dependencies = [
  "anyhow",
  "color-backtrace",
  "dialoguer",
- "dirs",
+ "dirs 2.0.2",
  "git2",
  "git2_credentials",
  "graphql_client",
  "log",
  "pretty_env_logger",
+ "prettytable-rs",
  "proptest",
  "regex",
  "reqwest",
@@ -343,6 +378,17 @@ dependencies = [
  "console",
  "lazy_static",
  "tempfile",
+]
+
+[[package]]
+name = "dirs"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3fd78930633bd1c6e35c4b42b1df7b0cbc6bc191146e512bb3bedf243fcc3901"
+dependencies = [
+ "libc",
+ "redox_users",
+ "winapi 0.3.8",
 ]
 
 [[package]]
@@ -599,7 +645,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac1fb05b04760ad0e642a12dd889a1b778becb12fbdb91306c72906ed9461b83"
 dependencies = [
  "dialoguer",
- "dirs",
+ "dirs 2.0.2",
  "git2",
 ]
 
@@ -1132,6 +1178,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "prettytable-rs"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fd04b170004fa2daccf418a7f8253aaf033c27760b5f225889024cf66d7ac2e"
+dependencies = [
+ "atty",
+ "csv",
+ "encode_unicode",
+ "lazy_static",
+ "term",
+ "unicode-width",
+]
+
+[[package]]
 name = "proc-macro-error"
 version = "0.4.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1402,6 +1462,15 @@ dependencies = [
  "memchr",
  "regex-syntax",
  "thread_local",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae1ded71d66a4a97f5e961fd0cb25a5f366a42a41570d16a763a69c092c26ae4"
+dependencies = [
+ "byteorder",
 ]
 
 [[package]]
@@ -1691,6 +1760,17 @@ dependencies = [
  "rand 0.7.3",
  "redox_syscall",
  "remove_dir_all",
+ "winapi 0.3.8",
+]
+
+[[package]]
+name = "term"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edd106a334b7657c10b7c540a0106114feadeb4dc314513e97df481d5d966f42"
+dependencies = [
+ "byteorder",
+ "dirs 1.0.5",
  "winapi 0.3.8",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ anyhow = "1.0.26"
 log = "0.4.8"
 color-backtrace = "0.3.0"
 pretty_env_logger = "0.4.0"
-
+prettytable-rs = "0.8.0"
 reqwest = { version = "0.10.3", features = ["blocking", "json", "gzip"] }
 graphql_client = "0.8.0"
 

--- a/USAGE.md
+++ b/USAGE.md
@@ -22,4 +22,12 @@ If you want to merge a branch `A` into branch `B`, you can check out branch `B` 
 
 ### Effect
 
-This command will try to simulate `git clean -f -d` command. It will clean all repositories that match a regex pattern.
+This command will try to simulate `git clean -f -d` command. It will clean all local repositories that match a regex pattern.
+
+## Status
+
+`dadmin status -o <org> -r <regex>`
+
+### Effect
+
+This command will try to show statuses of all local repositories that match a regex pattern.

--- a/USAGE.md
+++ b/USAGE.md
@@ -26,7 +26,7 @@ This command will try to simulate `git clean -f -d` command. It will clean all l
 
 ## Status
 
-`dadmin status -o <org> -r <regex>`
+`dadmin status -o <org> -r <regex> --verbose`
 
 ### Effect
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,6 +1,6 @@
 use crate::commands::{
-    AddArgs, ApplyArgs, BranchArgs, CheckoutArgs, CloneArgs, CreateArgs, InitArgs, MergeArgs,
-    PushArgs, RemoveArgs, SetArgs, ShowArgs, StatusArgs, CleanArgs,
+    AddArgs, ApplyArgs, BranchArgs, CheckoutArgs, CleanArgs, CloneArgs, CreateArgs, InitArgs,
+    MergeArgs, PushArgs, RemoveArgs, SetArgs, ShowArgs, StatusArgs,
 };
 use structopt::StructOpt;
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,6 +1,6 @@
 use crate::commands::{
-    AddArgs, ApplyArgs, BranchArgs, CheckoutArgs, CleanArgs, CloneArgs, CreateArgs, InitArgs,
-    MergeArgs, PushArgs, RemoveArgs, SetArgs, ShowArgs,
+    AddArgs, ApplyArgs, BranchArgs, CheckoutArgs, CloneArgs, CreateArgs, InitArgs, MergeArgs,
+    PushArgs, RemoveArgs, SetArgs, ShowArgs, StatusArgs, CleanArgs,
 };
 use structopt::StructOpt;
 
@@ -39,4 +39,6 @@ pub enum Commands {
     Set(SetArgs),
     #[structopt(name = "show")]
     Show(ShowArgs),
+    #[structopt(name = "status")]
+    Status(StatusArgs),
 }

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -1,5 +1,4 @@
 pub mod add;
-pub mod status;
 pub mod add_users;
 pub mod apply;
 pub mod branch;
@@ -26,6 +25,7 @@ pub mod set_team_permission;
 pub mod show;
 pub mod show_config;
 pub mod show_repos;
+pub mod status;
 
 pub use add::*;
 pub use apply::*;

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -1,4 +1,5 @@
 pub mod add;
+pub mod status;
 pub mod add_users;
 pub mod apply;
 pub mod branch;
@@ -41,3 +42,4 @@ pub use remove::*;
 pub use remove_repos::*;
 pub use set::*;
 pub use show::*;
+pub use status::*;

--- a/src/commands/status.rs
+++ b/src/commands/status.rs
@@ -77,6 +77,7 @@ fn status(dir: &PathBuf, verbose: bool) -> Result<()> {
 }
 
 fn show_summarize(status: &git::GitStatus) {
+    show_number_of_changes("conflicted files:", &status.conflicted);
     show_number_of_changes("untracked files:", &status.new);
     show_number_of_changes("deleted files:", &status.deleted);
     show_number_of_changes("modified files:", &status.modified);
@@ -85,6 +86,7 @@ fn show_summarize(status: &git::GitStatus) {
 }
 
 fn show_detail(status: &git::GitStatus) {
+    show_detail_changes("conflicted files:", &status.conflicted);
     show_detail_changes("untracked files:", &status.new);
     show_detail_changes("deleted files:", &status.deleted);
     show_detail_changes("modified files:", &status.modified);

--- a/src/commands/status.rs
+++ b/src/commands/status.rs
@@ -1,0 +1,22 @@
+use super::common;
+use crate::filter::Filter;
+use crate::git;
+use crate::path::local_path_org;
+use anyhow::{Context, Result};
+use std::path::PathBuf;
+use structopt::StructOpt;
+
+#[derive(Debug, StructOpt)]
+pub struct StatusArgs {
+    #[structopt(long, short, default_value = "divvun")]
+    pub organisation: String,
+    #[structopt(long, short)]
+    pub regex: Option<Filter>,
+}
+
+impl StatusArgs {
+    pub fn run(&self) -> Result<()> {
+        println!("Run");
+        Ok(())
+    }
+}

--- a/src/commands/status.rs
+++ b/src/commands/status.rs
@@ -16,7 +16,47 @@ pub struct StatusArgs {
 
 impl StatusArgs {
     pub fn run(&self) -> Result<()> {
-        println!("Run");
+        let target_dir = local_path_org(&self.organisation)?;
+
+        let sub_dirs = common::read_dirs_with_option(&target_dir, &self.regex)?;
+
+        for dir in sub_dirs {
+            if let Err(e) = status(&dir) {
+                println!(
+                    "Failed to status git status for dir {:?} because {:?}",
+                    dir, e
+                );
+            }
+        }
         Ok(())
+    }
+}
+
+fn status(dir: &PathBuf) -> Result<()> {
+    println!("Status for {:?}:", dir);
+    let git_repo = git::open(dir).with_context(|| format!("{:?} is not a git directory.", dir))?;
+    let status = git::status(&git_repo)?;
+
+    if status.is_empty() {
+        println!("Nothing change!")
+    } else {
+        show_status("New files:", &status.new);
+        show_status("Deleted files:", &status.deleted);
+        show_status("Modified files:", &status.modified);
+        show_status("Renamed files:", &status.renamed);
+        show_status("Typechanges files:", &status.typechanges);
+    }
+
+    println!();
+
+    Ok(())
+}
+
+fn show_status(msg: &str, list: &[String]) {
+    if !list.is_empty() {
+        println!("{}", msg);
+        for l in list {
+            println!("{}", l);
+        }
     }
 }

--- a/src/git/branch.rs
+++ b/src/git/branch.rs
@@ -20,6 +20,14 @@ pub fn create_branch<'a>(
     repo.branch(new_branch, &commit, false)
 }
 
+pub fn head_shorthand(repo: &Repository) -> Result<String> {
+    let head_ref = repo.head()?;
+    if let Some(name) = head_ref.shorthand() {
+        return Ok(name.to_string());
+    }
+    Err(anyhow!("Current branch name is not valid utf-8"))
+}
+
 pub fn checkout_local_branch(repo: &Repository, branch_name: &str) -> Result<()> {
     let obj = repo.revparse_single(&("refs/heads/".to_owned() + branch_name))?;
     repo.checkout_tree(&obj, None)?;

--- a/src/git/status.rs
+++ b/src/git/status.rs
@@ -39,9 +39,6 @@ pub fn status(repo: &Repository) -> Result<GitStatus, Error> {
     let mut conflicted = vec![];
 
     for entry in git_statuses.iter() {
-        if let Some(path) = entry.path() {
-            log::debug!("status path {}, {:?}", path, entry.status());
-        }
         let status = &entry.status();
         if git2::Status::is_wt_new(status) {
             if let Some(path) = entry.path() {

--- a/src/git/status.rs
+++ b/src/git/status.rs
@@ -38,9 +38,7 @@ pub fn status(repo: &Repository) -> Result<GitStatus, Error> {
     let mut typechanges = vec![];
     let mut conflicted = vec![];
 
-    for entry in git_statuses
-        .iter()
-    {
+    for entry in git_statuses.iter() {
         if let Some(path) = entry.path() {
             log::debug!("status path {}, {:?}", path, entry.status());
         }

--- a/src/git/status.rs
+++ b/src/git/status.rs
@@ -4,6 +4,19 @@ use git2::{Error, Repository, StatusOptions};
 pub struct GitStatus {
     pub new: Vec<String>,
     pub modified: Vec<String>,
+    pub deleted: Vec<String>,
+    pub renamed: Vec<String>,
+    pub typechanges: Vec<String>,
+}
+
+impl GitStatus {
+    pub fn is_empty(&self) -> bool {
+        self.new.is_empty()
+            && self.modified.is_empty()
+            && self.deleted.is_empty()
+            && self.renamed.is_empty()
+            && self.typechanges.is_empty()
+    }
 }
 
 pub fn status(repo: &Repository) -> Result<GitStatus, Error> {
@@ -16,7 +29,9 @@ pub fn status(repo: &Repository) -> Result<GitStatus, Error> {
     let git_statuses = repo.statuses(Some(&mut opts))?;
     let mut new_files = vec![];
     let mut modified = vec![];
-    //let mut deleted = vec![];
+    let mut deleted = vec![];
+    let mut renamed = vec![];
+    let mut typechanges = vec![];
 
     for entry in git_statuses
         .iter()
@@ -28,26 +43,34 @@ pub fn status(repo: &Repository) -> Result<GitStatus, Error> {
                 new_files.push(path.to_string());
             }
         };
-        //if git2::Status::is_wt_deleted(status) {
-        //if let Some(path) = entry.path {
-        //deleted.push(path.to_string());
-        //}
-        //};
-        //if git2::Status::is_wt_renamed(status) {
-        //statuses_in_dir.push("renames".to_string());
-        //};
-        //if git2::Status::is_wt_typechange(status) {
-        //statuses_in_dir.push("typechanges".to_string());
-        //};
+        if git2::Status::is_wt_deleted(status) {
+            if let Some(path) = entry.path() {
+                deleted.push(path.to_string());
+            }
+        };
+        if git2::Status::is_wt_renamed(status) {
+            if let Some(path) = entry.path() {
+                renamed.push(path.to_string());
+            }
+        };
+        if git2::Status::is_wt_typechange(status) {
+            if let Some(path) = entry.path() {
+                typechanges.push(path.to_string());
+            }
+        };
         if git2::Status::is_wt_modified(status) {
             if let Some(path) = entry.path() {
                 modified.push(path.to_string());
             }
         };
     }
+
     let status = GitStatus {
         new: new_files,
         modified,
+        deleted,
+        renamed,
+        typechanges,
     };
 
     Ok(status)

--- a/src/main.rs
+++ b/src/main.rs
@@ -38,5 +38,6 @@ fn main() -> Result<()> {
         Commands::Remove(args) => args.run(),
         Commands::Set(args) => args.run(),
         Commands::Show(args) => args.run(),
+        Commands::Status(args) => args.run(),
     }
 }


### PR DESCRIPTION
Close #30 

## Usage

`dadmin status -o <org> -r <regex> --verbose`

## Effect

This command will try to show statuses of all local repositories that match a regex pattern.

## Output

With `--verbose` flag
```
Status for repos in org dadmin-test

+----------------------------------------------------+
| Repo                branch        ±origin  U D M C |
+====================================================+
| test-1              master        2        1 1 1 0 |
| U new-changelog.md                                 |
| D changelog.md                                     |
| M README.md                                        |
| ----                                               |
| private-test-2      master        0        0 0 0 0 |
| test-2              master        0        0 0 0 0 |
| private-test-1      thanh-branch  0        0 0 0 0 |
| =====                                              |
| Total                             1        1       |
+----------------------------------------------------+

```

Without `--verbose` flag
```

Status for repos in org dadmin-test

+------------------------------------------------+
| Repo            branch        ±origin  U D M C |
+================================================+
| test-1          master        2        1 1 1 0 |
| private-test-2  master        0        0 0 0 0 |
| test-2          master        0        0 0 0 0 |
| private-test-1  thanh-branch  0        0 0 0 0 |
| =====                                          |
| Total                         1        1       |
+------------------------------------------------+

```