### PR TITLE
Set GitHub description website

### DIFF
--- a/USAGE.md
+++ b/USAGE.md
@@ -153,3 +153,23 @@ SUBCOMMANDS:
     private
     public
 ```
+
+## Set info
+
+```
+dadmin-set-info 0.1.0
+Set description and/or website for all repositories that match regex
+
+USAGE:
+    dadmin set info [OPTIONS] --regex <regex>
+
+FLAGS:
+    -h, --help       Prints help information
+    -V, --version    Prints version information
+
+OPTIONS:
+    -d, --description <description>      Description, this is required unless website is provided
+    -o, --organisation <organisation>    Target organisation name [default: divvun]
+    -r, --regex <regex>                  Optional regex to filter repositories
+    -w, --website <website>              Hompage, this is required unless description is provided
+```

--- a/USAGE.md
+++ b/USAGE.md
@@ -128,3 +128,28 @@ OPTIONS:
     -r, --regex <regex>                  Optional regex to filter repositories
 
 ```
+
+## Make
+
+Change visibilities of repositories
+
+```
+dadmin-make 0.1.0
+Make repositories that match a regex become public/private
+
+USAGE:
+    dadmin make [OPTIONS] --regex <regex> <SUBCOMMAND>
+
+FLAGS:
+    -h, --help       Prints help information
+    -V, --version    Prints version information
+
+OPTIONS:
+    -o, --organisation <organisation>    Target organisation name [default: divvun]
+    -r, --regex <regex>                  Regex to filter repositories
+
+SUBCOMMANDS:
+    help       Prints this message or the help of the given subcommand(s)
+    private
+    public
+```

--- a/src/commands/common.rs
+++ b/src/commands/common.rs
@@ -36,7 +36,7 @@ pub fn user_token() -> Result<String> {
 }
 
 fn remote_repos(token: &str, org: &str) -> Result<Vec<RemoteRepo>> {
-    match github::list_org_repos(token, org).context("Fetching repositories") {
+    match github::list_org_repos(token, org).context("When fetching repositories") {
         Ok(repos) => Ok(repos),
         Err(e) => {
             if e.downcast_ref::<NoReposFound>().is_some() {

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -26,6 +26,7 @@ pub mod remove;
 pub mod remove_repos;
 pub mod remove_users;
 pub mod set;
+pub mod set_info;
 pub mod set_team_permission;
 pub mod show;
 pub mod show_config;

--- a/src/commands/set.rs
+++ b/src/commands/set.rs
@@ -1,17 +1,23 @@
+use super::set_info::*;
 use super::set_team_permission::*;
 use anyhow::Result;
 use structopt::StructOpt;
 
 #[derive(Debug, StructOpt)]
 pub enum SetArgs {
+    #[structopt(name = "info")]
+    /// Set repos info
+    Info(InfoArgs),
     #[structopt(name = "permission")]
-    Persmission(SetTeamPermissionArgs),
+    /// Set team permission
+    Permission(SetTeamPermissionArgs),
 }
 
 impl SetArgs {
     pub fn run(&self) -> Result<()> {
         match self {
-            SetArgs::Persmission(args) => args.set_permission(),
+            SetArgs::Permission(args) => args.set_permission(),
+            SetArgs::Info(args) => args.run(),
         }
     }
 }

--- a/src/commands/set.rs
+++ b/src/commands/set.rs
@@ -6,10 +6,8 @@ use structopt::StructOpt;
 #[derive(Debug, StructOpt)]
 pub enum SetArgs {
     #[structopt(name = "info")]
-    /// Set repos info
     Info(InfoArgs),
     #[structopt(name = "permission")]
-    /// Set team permission
     Permission(SetTeamPermissionArgs),
 }
 

--- a/src/commands/set_info.rs
+++ b/src/commands/set_info.rs
@@ -16,8 +16,10 @@ pub struct InfoArgs {
     /// Optional regex to filter repositories
     pub regex: Filter,
     #[structopt(long, short)]
+    /// Description, this is required unless website is provided
     pub description: Option<String>,
     #[structopt(long, short)]
+    /// Hompage, this is required unless description is provided
     pub website: Option<String>,
 }
 

--- a/src/commands/set_info.rs
+++ b/src/commands/set_info.rs
@@ -1,0 +1,55 @@
+use super::common;
+use crate::github;
+
+use anyhow::Result;
+
+use crate::filter::Filter;
+use structopt::StructOpt;
+
+#[derive(Debug, StructOpt)]
+/// Set description and/or website for all repositories that match regex
+pub struct InfoArgs {
+    #[structopt(long, short, default_value = "divvun")]
+    /// Target organisation name
+    pub organisation: String,
+    #[structopt(long, short)]
+    /// Optional regex to filter repositories
+    pub regex: Filter,
+    #[structopt(long, short)]
+    pub description: Option<String>,
+    #[structopt(long, short)]
+    pub website: Option<String>,
+}
+
+impl InfoArgs {
+    pub fn run(&self) -> Result<()> {
+        if self.description.is_none() && self.website.is_none() {
+            println!(
+                "There is nothing to set, please input description or website to set repos info."
+            );
+            return Ok(());
+        }
+
+        let user_token = common::user_token()?;
+
+        let filtered_repos = common::query_and_filter_repositories(
+            &self.organisation,
+            Some(&self.regex),
+            &user_token,
+        )?;
+
+        for repo in filtered_repos {
+            let result = github::set_repo_metadata(
+                &repo,
+                self.description.as_deref(),
+                self.website.as_deref(),
+                &user_token,
+            );
+            match result {
+                Ok(_) => println!("Set info for repo {} successfully", repo.name),
+                Err(e) => println!("Failed to set info for repo {} because {:?}", repo.name, e),
+            }
+        }
+        Ok(())
+    }
+}

--- a/src/github/rest.rs
+++ b/src/github/rest.rs
@@ -68,6 +68,7 @@ struct UpdateRepoBody {
     default_branch: Option<String>,
     private: Option<bool>,
     description: Option<String>,
+    homepage: Option<String>,
 }
 
 impl UpdateRepoBody {
@@ -76,6 +77,7 @@ impl UpdateRepoBody {
             default_branch: Some(branch.to_string()),
             private: None,
             description: None,
+            homepage: None,
         }
     }
 
@@ -84,6 +86,16 @@ impl UpdateRepoBody {
             default_branch: None,
             private: Some(is_private),
             description: None,
+            homepage: None,
+        }
+    }
+
+    fn metadata(des: Option<&str>, homepage: Option<&str>) -> UpdateRepoBody {
+        UpdateRepoBody {
+            default_branch: None,
+            private: None,
+            description: des.map(|s| s.to_string()),
+            homepage: homepage.map(|s| s.to_string()),
         }
     }
 }
@@ -99,6 +111,19 @@ pub fn set_default_branch(repo: &RemoteRepo, branch: &str, token: &str) -> Resul
 pub fn set_repo_visibility(repo: &RemoteRepo, is_private: bool, token: &str) -> Result<()> {
     let url = format!("https://api.github.com/repos/{}/{}", repo.owner, repo.name);
     let body = UpdateRepoBody::repo_visibility(is_private);
+    let response = patch(&url, &body, token)?;
+
+    process_response(&response).map(|_| ())
+}
+
+pub fn set_repo_metadata(
+    repo: &RemoteRepo,
+    des: Option<&str>,
+    homepage: Option<&str>,
+    token: &str,
+) -> Result<()> {
+    let url = format!("https://api.github.com/repos/{}/{}", repo.owner, repo.name);
+    let body = UpdateRepoBody::metadata(des, homepage);
     let response = patch(&url, &body, token)?;
 
     process_response(&response).map(|_| ())


### PR DESCRIPTION
Close #66 

Usage Set info

```
dadmin-set-info 0.1.0
Set description and/or website for all repositories that match regex
USAGE:
    dadmin set info [OPTIONS] --regex <regex>
FLAGS:
    -h, --help       Prints help information
    -V, --version    Prints version information
OPTIONS:
    -d, --description <description>      Description, this is required unless website is provided
    -o, --organisation <organisation>    Target organisation name [default: divvun]
    -r, --regex <regex>                  Optional regex to filter repositories
    -w, --website <website>              Hompage, this is required unless description is provided
```